### PR TITLE
add -grpc suffix to kpt service.yaml

### DIFF
--- a/kubernetes/kpt/service.yaml
+++ b/kubernetes/kpt/service.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     app: bootes
   ports:
-  - name: xds
+  - name: xds-grpc
     protocol: TCP
     port: 5000
     targetPort: 5000


### PR DESCRIPTION
to follow Istio convention: https://istio.io/docs/ops/configuration/traffic-management/protocol-selection/