### PR TITLE
kpt: fix service name to follow Istio convention

### DIFF
--- a/kubernetes/kpt/service.yaml
+++ b/kubernetes/kpt/service.yaml
@@ -9,7 +9,7 @@ spec:
   selector:
     app: bootes
   ports:
-  - name: xds-grpc
+  - name: grpc-xds
     protocol: TCP
     port: 5000
     targetPort: 5000


### PR DESCRIPTION
#54 introduce wrong service name. This fixes it.