### PR TITLE
log: use EpochMillisTimeEncoder

### DIFF
--- a/internal/server/logger.go
+++ b/internal/server/logger.go
@@ -21,7 +21,7 @@ func newLogger() (logr.Logger, error) {
 			MessageKey:     "message",
 			LineEnding:     zapcore.DefaultLineEnding,
 			EncodeLevel:    zapcore.LowercaseLevelEncoder,
-			EncodeTime:     zapcore.EpochTimeEncoder,
+			EncodeTime:     zapcore.EpochMillisTimeEncoder,
 			EncodeDuration: zapcore.SecondsDurationEncoder,
 		},
 		OutputPaths:      []string{"stdout"},


### PR DESCRIPTION
Some logging services (e.g Datadog) use milliseconds epoch instead just epoch time. https://docs.datadoghq.com/logs/processing/processors/?tab=ui#log-date-remapper