### PR TITLE
set GOPROXY='direct'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /go/src/github.com/110y/bootes
 
 COPY go.mod go.mod
 COPY go.sum go.sum
-RUN go mod download
+RUN GOPROXY='direct' go mod download
 
 COPY . .
 RUN go build -o /usr/bin/bootes .


### PR DESCRIPTION
With `proxy.golang.org`, I often caught errors attached below when I build the container.
I'm not sure why but I guess it is caused by too many TPS.

```
Step 8/13 : RUN go mod download
 ---> Running in 998b967d3809
github.com/OneOfOne/xxhash@v1.2.2: Get "https://proxy.golang.org/github.com/%21one%21of%21one/xxhash/@v/v1.2.2.zip": read tcp 172.17.0.3:38984->172.217.161.81:443: read: connection reset by peer
github.com/mattn/go-colorable@v0.1.2: Get "https://proxy.golang.org/github.com/mattn/go-colorable/@v/v0.1.2.zip": read tcp 172.17.0.3:39310->172.217.161.81:443: read: connection reset by peer
github.com/mattn/go-isatty@v0.0.12: Get "https://proxy.golang.org/github.com/mattn/go-isatty/@v/v0.0.12.zip": read tcp 172.17.0.3:39310->172.217.161.81:443: read: connection reset by peer
github.com/pkg/profile@v0.0.0-20170413231811-06b906832ed0: Get "https://proxy.golang.org/github.com/pkg/profile/@v/v0.0.0-20170413231811-06b906832ed0.zip": read tcp 172.17.0.3:38984->172.217.161.81:443: read: connection reset by peer
github.com/pquerna/cachecontrol@v0.0.0-20171018203845-0dec1b30a021: Get "https://proxy.golang.org/github.com/pquerna/cachecontrol/@v/v0.0.0-20171018203845-0dec1b30a021.zip": read tcp 172.17.0.3:38984->172.217.161.81:443: read: connection reset by peer
golang.org/x/text@v0.3.2: read tcp 172.17.0.3:38984->172.217.161.81:443: read: connection reset by peer
gonum.org/v1/gonum@v0.0.0-20190331200053-3d26580ed485: read tcp 172.17.0.3:38984->172.217.161.81:443: read: connection reset by peer
gopkg.in/alecthomas/kingpin.v2@v2.2.6: Get "https://proxy.golang.org/gopkg.in/alecthomas/kingpin.v2/@v/v2.2.6.zip": read tcp 172.17.0.3:39310->172.217.161.81:443: read: connection reset by peer
k8s.io/kubectl@v0.0.0-20191219154910-1528d4eea6dd: Get "https://proxy.golang.org/k8s.io/kubectl/@v/v0.0.0-20191219154910-1528d4eea6dd.zip": read tcp 172.17.0.3:39310->172.217.161.81:443: read: connection reset by peer
rsc.io/binaryregexp@v0.2.0: read tcp 172.17.0.3:38984->172.217.161.81:443: read: connection reset by peer
sigs.k8s.io/structured-merge-diff@v1.0.1-0.20191108220359-b1b620dd3f06: read tcp 172.17.0.3:39310->172.217.161.81:443: read: connection reset by peer
sigs.k8s.io/structured-merge-diff/v3@v3.0.0: Get "https://proxy.golang.org/sigs.k8s.io/structured-merge-diff/v3/@v/v3.0.0.zip": read tcp 172.17.0.3:38984->172.217.161.81:443: read: connection reset by peer
exiting dev mode because first build failed: couldn't build "bootes": unable to stream build output: The command '/bin/sh -c go mod download' returned a non-zero code: 1
```