### PR TITLE
ci: bake image on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
         run: go build -o bootes .
 
   image:
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/main'
     needs:
       - lint
       - test


### PR DESCRIPTION
- bake image on when the commits were merged into the `main` branch instead `master`.